### PR TITLE
Tokenize and Cook Unicode Identifiers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ async function test_dev() {
 	}
 
 	const parser = new Parser(await input)
-	let tree = ''
+	let tree;
 	try {
 		tree = parser.parse()
 	} catch (err) {
@@ -75,11 +75,23 @@ const build = gulp.series(dist, test)
 const dev = gulp.series(dist, test_dev)
 
 async function random() {
+	const {Parser} = require('./')
 	const {default: Grammar} = require('./build/class/Grammar.class')
-	const solid_grammar = new Grammar()
-	console.log(solid_grammar.rules.map((r) => r.toString()))
-	console.log(solid_grammar.random().join(' ').replace(/\u000d/g, ' '))
-	return Promise.resolve(null)
+	const sample = new Grammar().random().join(' ').replace(/\u0002|\u0003/g, '') // inserted by Scanner
+	console.log(sample.replace(/\u000d/g, '\u240d'))
+	const parser = new Parser(sample)
+	let tree;
+	try {
+		tree = parser.parse()
+	} catch (err) {
+		console.log(parser.viewStack())
+		throw err
+	}
+	return Promise.all([
+		fsPromise.writeFile('./sample/output.xml', tree.serialize()),
+		fsPromise.writeFile('./sample/output-1.xml', tree.decorate().serialize()),
+		fsPromise.writeFile('./sample/output-2.ts', tree.decorate().compile()),
+	])
 }
 
 

--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -578,10 +578,8 @@ The Word Value (WV) of a word token is the unique identifier that distinguishes
 the word from other words in a program.
 
 ```w3c
-WV(Word ::= ([A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`") - Keyword)
-	:= /* TO BE DETERMINED */
-WV(Word ::= Keyword)
-	:= the contents of the token
+WV(Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`")
+	:= /* TO BE DESCRIBED */
 ```
 
 #### Static Semantics: Decoration (Words)

--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -549,7 +549,7 @@ where `MV` is [Mathematical Value](./#static-semantics-mathematical-value).
 
 ### Words
 ```w3c
-Word ::= [A-Za-z_] [A-Za-z0-9_]*
+Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`"
 Identifier ::= Word - Keyword
 
 Keyword ::=
@@ -578,7 +578,7 @@ The Word Value (WV) of a word token is the unique identifier that distinguishes
 the word from other words in a program.
 
 ```w3c
-WV(Word ::= Identifier)
+WV(Word ::= ([A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`") - Keyword)
 	:= /* TO BE DETERMINED */
 WV(Word ::= Keyword)
 	:= the contents of the token

--- a/src/class/Lexer.class.ts
+++ b/src/class/Lexer.class.ts
@@ -128,7 +128,9 @@ export default class Lexer {
 				token = new TokenNumber(this, false)
 
 			} else if (TokenWord.CHAR_START.test(this._c0.source)) {
-				token = new TokenWord(this)
+				token = new TokenWord(this, false)
+			} else if (Char.eq(TokenWord.DELIM, this._c0)) {
+				token = new TokenWord(this, true)
 
 			} else if (Char.inc(TokenPunctuator.CHARS_3, this._c0, this._c1, this._c2)) {
 				token = new TokenPunctuator(this, 3)

--- a/src/class/Lexer.class.ts
+++ b/src/class/Lexer.class.ts
@@ -9,7 +9,7 @@ import Token, {
 	TokenString,
 	TokenTemplate,
 	TokenNumber,
-	TokenWordStandard,
+	TokenWordBasic,
 	TokenWordUnicode,
 	TokenPunctuator,
 } from './Token.class'
@@ -128,8 +128,8 @@ export default class Lexer {
 			} else if (Char.inc(TokenNumber.DIGITS.get(TokenNumber.RADIX_DEFAULT) !, this._c0)) {
 				token = new TokenNumber(this, false)
 
-			} else if (TokenWordStandard.CHAR_START.test(this._c0.source)) {
-				token = new TokenWordStandard(this)
+			} else if (TokenWordBasic.CHAR_START.test(this._c0.source)) {
+				token = new TokenWordBasic(this)
 			} else if (Char.eq(TokenWordUnicode.DELIM, this._c0)) {
 				token = new TokenWordUnicode(this)
 

--- a/src/class/Lexer.class.ts
+++ b/src/class/Lexer.class.ts
@@ -9,7 +9,8 @@ import Token, {
 	TokenString,
 	TokenTemplate,
 	TokenNumber,
-	TokenWord,
+	TokenWordStandard,
+	TokenWordUnicode,
 	TokenPunctuator,
 } from './Token.class'
 
@@ -127,10 +128,10 @@ export default class Lexer {
 			} else if (Char.inc(TokenNumber.DIGITS.get(TokenNumber.RADIX_DEFAULT) !, this._c0)) {
 				token = new TokenNumber(this, false)
 
-			} else if (TokenWord.CHAR_START.test(this._c0.source)) {
-				token = new TokenWord(this, false)
-			} else if (Char.eq(TokenWord.DELIM, this._c0)) {
-				token = new TokenWord(this, true)
+			} else if (TokenWordStandard.CHAR_START.test(this._c0.source)) {
+				token = new TokenWordStandard(this)
+			} else if (Char.eq(TokenWordUnicode.DELIM, this._c0)) {
+				token = new TokenWordUnicode(this)
 
 			} else if (Char.inc(TokenPunctuator.CHARS_3, this._c0, this._c1, this._c2)) {
 				token = new TokenPunctuator(this, 3)

--- a/src/class/ParseNode.class.ts
+++ b/src/class/ParseNode.class.ts
@@ -117,10 +117,10 @@ export default class ParseNode implements Serializable {
 	 * @implements Serializable
 	 */
 	serialize(): string {
-		const attributes: Map<string, string|number|boolean|null> = new Map<string, string|number|boolean|null>()
+		const attributes: Map<string, string> = new Map<string, string>()
 		if (!(this instanceof ParseNodeGoal)) {
-			attributes.set('line', this.line_index + 1)
-			attributes.set('col' , this.col_index  + 1)
+			attributes.set('line', `${this.line_index + 1}`)
+			attributes.set('col' , `${this.col_index  + 1}`)
 		}
 		attributes.set('source', this.source
 			.replace(/\&/g, '&amp;' )

--- a/src/class/Screener.class.ts
+++ b/src/class/Screener.class.ts
@@ -1,5 +1,4 @@
 import Lexer from './Lexer.class'
-import {STX, ETX} from './Char.class'
 import Token, {
 	TokenWhitespace,
 	TokenComment,
@@ -39,15 +38,6 @@ export default class Screener {
 	}
 
 	/**
-	 * Return a list of unique identifiers in the program,
-	 * in the order they appeared.
-	 * @returns a list of unique identifiers
-	 */
-	get identifiers(): string[] {
-		return [...this._ids]
-	}
-
-	/**
 	 * Prepare the next token for the parser.
 	 * Whitespace and comment tokens are filtered out.
 	 * @returns the next token
@@ -57,7 +47,7 @@ export default class Screener {
 			if (!(this.t0 instanceof TokenWhitespace) && !(this.t0 instanceof TokenComment)) {
 				if (this.t0 instanceof TokenWord && this.t0.is_identifier) {
 					this._ids.add(this.t0.source)
-					this.t0.setValue(this)
+					this.t0.setValue([...this._ids].indexOf(this.t0.source))
 				}
 				if (this.t0 instanceof Token) {
 					yield this.t0

--- a/src/class/Screener.class.ts
+++ b/src/class/Screener.class.ts
@@ -3,6 +3,7 @@ import Token, {
 	TokenWhitespace,
 	TokenComment,
 	TokenWord,
+	TokenWordBasic,
 } from './Token.class'
 
 
@@ -45,9 +46,17 @@ export default class Screener {
 	* generate(): Iterator<Token, void> {
 		while (!this.iterator_result_token.done) {
 			if (!(this.t0 instanceof TokenWhitespace) && !(this.t0 instanceof TokenComment)) {
-				if (this.t0 instanceof TokenWord && this.t0.isIdentifier) {
-					this._ids.add(this.t0.source)
-					this.t0.setValue([...this._ids].indexOf(this.t0.source))
+				if (this.t0 instanceof TokenWord) {
+					if (!this.t0.isIdentifier) {
+						const value: number = [...TokenWordBasic.KEYWORDS]
+							.flatMap(([_, reserved]) => reserved)
+							.indexOf(this.t0.source)
+						if (value < 0) throw new Error('A word token was not flagged as an identifier but was not found among the reserved keywords.')
+						this.t0.setValue(BigInt(value))
+					} else {
+						this._ids.add(this.t0.source)
+						this.t0.setValue(BigInt([...this._ids].indexOf(this.t0.source)) + 128n) // bypass all the reserved keywords
+					}
 				}
 				if (this.t0 instanceof Token) {
 					yield this.t0

--- a/src/class/Screener.class.ts
+++ b/src/class/Screener.class.ts
@@ -45,7 +45,7 @@ export default class Screener {
 	* generate(): Iterator<Token, void> {
 		while (!this.iterator_result_token.done) {
 			if (!(this.t0 instanceof TokenWhitespace) && !(this.t0 instanceof TokenComment)) {
-				if (this.t0 instanceof TokenWord && this.t0.is_identifier) {
+				if (this.t0 instanceof TokenWord && this.t0.isIdentifier) {
 					this._ids.add(this.t0.source)
 					this.t0.setValue([...this._ids].indexOf(this.t0.source))
 				}

--- a/src/class/SemanticNode.class.ts
+++ b/src/class/SemanticNode.class.ts
@@ -163,7 +163,7 @@ export class SemanticNodeTemplate extends SemanticNode {
 	}
 }
 export class SemanticNodeIdentifier extends SemanticNode {
-	constructor(canonical: Token, id: string|number) {
+	constructor(canonical: Token, id: bigint|null) {
 		super(canonical, {id})
 	}
 }

--- a/src/class/SemanticNode.class.ts
+++ b/src/class/SemanticNode.class.ts
@@ -2,6 +2,7 @@ import Util from './Util.class'
 import Serializable from '../iface/Serializable.iface'
 import {STX, ETX} from './Char.class'
 import Token from './Token.class'
+import {CookValueType} from './Token.class'
 import ParseNode from './ParseNode.class'
 
 
@@ -32,7 +33,7 @@ export default class SemanticNode implements Serializable {
 	 */
 	constructor(
 		start_node: Token|ParseNode,
-		private readonly attributes: { [key: string]: string|number|boolean|null } = {},
+		private readonly attributes: { [key: string]: CookValueType } = {},
 		readonly children: readonly SemanticNode[] = [],
 	) {
 		this.tagname      = this.constructor.name.slice('SemanticNode'.length) || 'Unknown'
@@ -57,10 +58,10 @@ export default void 0
 	 * @implements Serializable
 	 */
 	serialize(): string {
-		const attributes: Map<string, string|number|boolean|null> = new Map<string, string|number|boolean|null>()
+		const attributes: Map<string, string> = new Map<string, string>()
 		if (!(this instanceof SemanticNodeGoal)) {
-			attributes.set('line', this.line_index + 1)
-			attributes.set('col' , this.col_index  + 1)
+			attributes.set('line', `${this.line_index + 1}`)
+			attributes.set('col' , `${this.col_index  + 1}`)
 		}
 		attributes.set('source', this.source
 			.replace(/\&/g, '&amp;' )
@@ -76,8 +77,8 @@ export default void 0
 			.replace(STX, '\u2402') /* SYMBOL FOR START OF TEXT */
 			.replace(ETX, '\u2403') /* SYMBOL FOR START OF TEXT */
 		)
-		Object.entries<string|number|boolean|null>(this.attributes).forEach(([key, value]) => {
-			attributes.set(key, value)
+		Object.entries<CookValueType>(this.attributes).forEach(([key, value]) => {
+			attributes.set(key, `${value}`)
 		})
 		const contents: string = this.children.map((child) => child.serialize()).join('')
 		return (contents) ? `<${this.tagname} ${Util.stringifyAttributes(attributes)}>${contents}</${this.tagname}>` : `<${this.tagname} ${Util.stringifyAttributes(attributes)}/>`

--- a/src/class/Terminal.class.ts
+++ b/src/class/Terminal.class.ts
@@ -147,6 +147,6 @@ export class TerminalIdentifier extends Terminal {
 		return returned
 	}
 	match(candidate: Token): boolean {
-		return candidate instanceof TokenWord && candidate.is_identifier
+		return candidate instanceof TokenWord && candidate.isIdentifier
 	}
 }

--- a/src/class/Terminal.class.ts
+++ b/src/class/Terminal.class.ts
@@ -5,7 +5,7 @@ import Token, {
 	TokenTemplate,
 	TokenNumber,
 	TokenWord,
-	TokenWordStandard,
+	TokenWordBasic,
 } from './Token.class'
 
 
@@ -172,13 +172,13 @@ export class TerminalNumber extends Terminal {
 export class TerminalIdentifier extends Terminal {
 	static readonly instance: TerminalIdentifier = new TerminalIdentifier()
 	random(): string {
-		const charsStandard = (start: boolean = false): string => {
+		const charsBasic = (start: boolean = false): string => {
 			let c: string;
-			const pass: RegExp = start ? TokenWordStandard.CHAR_START : TokenWordStandard.CHAR_REST
+			const pass: RegExp = start ? TokenWordBasic.CHAR_START : TokenWordBasic.CHAR_REST
 			do {
 				c = Util.randomChar()
 			} while (!pass.test(c))
-			return start ? c : `${c}${Util.randomBool() ? '' : charsStandard()}`
+			return start ? c : `${c}${Util.randomBool() ? '' : charsBasic()}`
 		}
 		const charsUnicode = (): string => {
 			return `${Util.randomBool() ? '' : charsUnicode()}${Util.randomChar(['`'])}`
@@ -186,8 +186,8 @@ export class TerminalIdentifier extends Terminal {
 		let returned: string;
 		if (Util.randomBool()) {
 			do {
-				returned = `${charsStandard(true)}${Util.randomBool() ? '' : charsStandard()}`
-			} while (([...TokenWordStandard.KEYWORDS.values()].flat() as string[]).includes(returned))
+				returned = `${charsBasic(true)}${Util.randomBool() ? '' : charsBasic()}`
+			} while (([...TokenWordBasic.KEYWORDS.values()].flat() as string[]).includes(returned))
 		} else {
 			returned = `\`${Util.randomBool() ? '' : charsUnicode()}\``
 		}

--- a/src/class/Terminal.class.ts
+++ b/src/class/Terminal.class.ts
@@ -5,6 +5,7 @@ import Token, {
 	TokenTemplate,
 	TokenNumber,
 	TokenWord,
+	TokenWordStandard,
 } from './Token.class'
 
 
@@ -132,18 +133,25 @@ export class TerminalNumber extends Terminal {
 export class TerminalIdentifier extends Terminal {
 	static readonly instance: TerminalIdentifier = new TerminalIdentifier()
 	random(): string {
-		const chars = (start: boolean = false): string => {
+		const charsStandard = (start: boolean = false): string => {
 			let c: string;
-			const pass: RegExp = start ? TokenWord.CHAR_START : TokenWord.CHAR_REST
+			const pass: RegExp = start ? TokenWordStandard.CHAR_START : TokenWordStandard.CHAR_REST
 			do {
 				c = Util.randomChar()
 			} while (!pass.test(c))
-			return start ? c : `${c}${Util.randomBool() ? '' : chars()}`
+			return start ? c : `${c}${Util.randomBool() ? '' : charsStandard()}`
+		}
+		const charsUnicode = (): string => {
+			return `${Util.randomBool() ? '' : charsUnicode()}${Util.randomChar(['`'])}`
 		}
 		let returned: string;
-		do {
-			returned = `${chars(true)}${Util.randomBool() ? '' : chars()}`
-		} while (([...TokenWord.KEYWORDS.values()].flat() as string[]).includes(returned))
+		if (Util.randomBool()) {
+			do {
+				returned = `${charsStandard(true)}${Util.randomBool() ? '' : charsStandard()}`
+			} while (([...TokenWordStandard.KEYWORDS.values()].flat() as string[]).includes(returned))
+		} else {
+			returned = `\`${Util.randomBool() ? '' : charsUnicode()}\``
+		}
 		return returned
 	}
 	match(candidate: Token): boolean {

--- a/src/class/Token.class.ts
+++ b/src/class/Token.class.ts
@@ -2,7 +2,6 @@ import Serializable from '../iface/Serializable.iface'
 import Util from './Util.class'
 import Char, {STX, ETX} from './Char.class'
 import Lexer from './Lexer.class'
-import Screener from './Screener.class'
 
 import {
 	LexError02,
@@ -530,7 +529,7 @@ export class TokenWord extends Token {
 	 * If the token is an identifier, the cooked value is set by a {@link Screener},
 	 * which indexes unique identifier tokens.
 	 */
-	private _cooked: number/* bigint */|string;
+	private _cooked: number|string;
 	/** Is this Token an identifier? */
 	readonly is_identifier: boolean;
 	constructor (lexer: Lexer) {
@@ -548,18 +547,19 @@ export class TokenWord extends Token {
 		this._cooked = this.source
 	}
 	/**
-	 * Use a Screener to set the value of this Token.
-	 * If this token is an identifier, get the index of this token’s contents
-	 * in the given screener’s list of unique identifier tokens.
+	 * If this Token is an identifier, set the numeric value.
 	 * Else if this token is a keyword, do nothing.
-	 * @param   screener the Screener whose indexed identifiers to search
+	 * The value should be the index of this token’s contents
+	 * in a given screener’s list of unique identifier tokens.
+	 * This operation can only be done once.
+	 * @param   value - the value to set, unique among all identifiers in a program
 	 */
-	setValue(screener: Screener) {
-		if (this.is_identifier) {
-			this._cooked = screener.identifiers.indexOf(this.source)
+	setValue(value: number): void {
+		if (typeof this._cooked === 'string' && this.is_identifier) {
+			this._cooked = value
 		}
 	}
-	cook(): number/* bigint */|string {
+	cook(): number|string {
 		return this._cooked
 	}
 }

--- a/src/class/Token.class.ts
+++ b/src/class/Token.class.ts
@@ -22,6 +22,8 @@ enum KeywordKind {
 	MODIFIER,
 }
 
+export type CookValueType = string|number|boolean|null
+
 
 
 /**
@@ -78,17 +80,17 @@ export default abstract class Token implements Serializable {
 	 * If this Token is not to be sent to the parser, then return `null`.
 	 * @returns              the computed value of this token, or `null`
 	 */
-	abstract cook(): string|number|boolean|null;
+	abstract cook(): CookValueType;
 
 	/**
 	 * @implements Serializable
 	 */
 	serialize(): string {
-		const cooked: string|number|boolean|null = this.cook()
-		const attributes: Map<string, string|number|boolean|null> = new Map<string, string|number|boolean|null>()
+		const cooked: CookValueType = this.cook()
+		const attributes: Map<string, string> = new Map<string, string>()
 		if (!(this instanceof TokenFilebound)) {
-			attributes.set('line', this.line_index + 1)
-			attributes.set('col' , this.col_index  + 1)
+			attributes.set('line', `${this.line_index + 1}`)
+			attributes.set('col' , `${this.col_index  + 1}`)
 		}
 		if (cooked !== null) {
 			attributes.set('value', (typeof cooked === 'string') ? cooked

--- a/src/class/Token.class.ts
+++ b/src/class/Token.class.ts
@@ -537,7 +537,7 @@ export abstract class TokenWord extends Token {
 		return this._cooked
 	}
 }
-export class TokenWordStandard extends TokenWord {
+export class TokenWordBasic extends TokenWord {
 	static readonly CHAR_START: RegExp = /^[A-Za-z_]$/
 	static readonly CHAR_REST : RegExp = /^[A-Za-z0-9_]$/
 	static readonly KEYWORDS: ReadonlyMap<KeywordKind, readonly string[]> = new Map<KeywordKind, readonly string[]>(([
@@ -553,12 +553,12 @@ export class TokenWordStandard extends TokenWord {
 	constructor(lexer: Lexer) {
 		const buffer: Char[] = [lexer.c0]
 		lexer.advance()
-		while (!lexer.isDone && TokenWordStandard.CHAR_REST.test(lexer.c0.source)) {
+		while (!lexer.isDone && TokenWordBasic.CHAR_REST.test(lexer.c0.source)) {
 			buffer.push(lexer.c0)
 			lexer.advance()
 		}
 		super(buffer[0], ...buffer.slice(1))
-		this.keyword_kind = ([...TokenWordStandard.KEYWORDS].find(
+		this.keyword_kind = ([...TokenWordBasic.KEYWORDS].find(
 			([_key, value]) => value.includes(this.source)
 		) || [null])[0]
 	}

--- a/src/class/Util.class.ts
+++ b/src/class/Util.class.ts
@@ -101,7 +101,7 @@ export default class Util {
 	 * @param   attributes a map of key-value pairs
 	 * @returns            an HTML string of space-separated attributes
 	 */
-	static stringifyAttributes(attributes: Map<string, string|number|boolean|null>): string {
+	static stringifyAttributes(attributes: Map<string, string>): string {
 		return [...attributes.entries()].map((([attr, val]) => `${attr}="${val}"`)).join(' ')
 	}
 }

--- a/src/lexical-grammar.ebnf
+++ b/src/lexical-grammar.ebnf
@@ -138,7 +138,7 @@ DigitSequenceHTD ::= (DigitSequenceHTD "_"?)? [0-9a-z]
 
 
 
-Word ::= [A-Za-z_] [A-Za-z0-9_]*
+Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`"
 Identifier ::= Word - Keyword
 
 

--- a/src/semantics-token-value.ebnf
+++ b/src/semantics-token-value.ebnf
@@ -258,7 +258,5 @@ MV([0-9a-z] ::= "z")  :=  35
 
 
 
-WV(Word ::= ([A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`") - Keyword)
-	:= /* TO BE DETERMINED */
-WV(Word ::= Keyword)
-	:= the contents of the token
+WV(Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`")
+	:= /* TO BE DESCRIBED */

--- a/src/semantics-token-value.ebnf
+++ b/src/semantics-token-value.ebnf
@@ -258,7 +258,7 @@ MV([0-9a-z] ::= "z")  :=  35
 
 
 
-WV(Word ::= Identifier)
+WV(Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`" - Keyword)
 	:= /* TO BE DETERMINED */
 WV(Word ::= Keyword)
 	:= the contents of the token

--- a/src/semantics-token-value.ebnf
+++ b/src/semantics-token-value.ebnf
@@ -258,7 +258,7 @@ MV([0-9a-z] ::= "z")  :=  35
 
 
 
-WV(Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`" - Keyword)
+WV(Word ::= ([A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`") - Keyword)
 	:= /* TO BE DETERMINED */
 WV(Word ::= Keyword)
 	:= the contents of the token

--- a/test/statement.test.js
+++ b/test/statement.test.js
@@ -56,9 +56,9 @@ the_answer = the_answer - \\z14;
 			<Goal__0__List line="1" col="1" source="let unfixed the_answer = 42 ;">
 				<Statement line="1" col="1" source="let unfixed the_answer = 42 ;">
 					<DeclarationVariable line="1" col="1" source="let unfixed the_answer = 42 ;">
-						<WORD line="1" col="1" value="let">let</WORD>
-						<WORD line="1" col="5" value="unfixed">unfixed</WORD>
-						<WORD line="1" col="13" value="0">the_answer</WORD>
+						<WORD line="1" col="1" value="0">let</WORD>
+						<WORD line="1" col="5" value="1">unfixed</WORD>
+						<WORD line="1" col="13" value="128">the_answer</WORD>
 						<PUNCTUATOR line="1" col="24" value="=">=</PUNCTUATOR>
 						<Expression line="1" col="26" source="42">
 							<ExpressionAdditive line="1" col="26" source="42">
@@ -81,8 +81,8 @@ the_answer = the_answer - \\z14;
 			</Goal__0__List>
 			<Statement line="2" col="1" source="let \`the £ answer\` = the_answer * 10 ;">
 				<DeclarationVariable line="2" col="1" source="let \`the £ answer\` = the_answer * 10 ;">
-					<WORD line="2" col="1" value="let">let</WORD>
-					<WORD line="2" col="5" value="1">\`the £ answer\`</WORD>
+					<WORD line="2" col="1" value="0">let</WORD>
+					<WORD line="2" col="5" value="129">\`the £ answer\`</WORD>
 					<PUNCTUATOR line="2" col="20" value="=">=</PUNCTUATOR>
 					<Expression line="2" col="22" source="the_answer * 10">
 						<ExpressionAdditive line="2" col="22" source="the_answer * 10">
@@ -91,7 +91,7 @@ the_answer = the_answer - \\z14;
 									<ExpressionExponential line="2" col="22" source="the_answer">
 										<ExpressionUnarySymbol line="2" col="22" source="the_answer">
 											<ExpressionUnit line="2" col="22" source="the_answer">
-												<WORD line="2" col="22" value="0">the_answer</WORD>
+												<WORD line="2" col="22" value="128">the_answer</WORD>
 											</ExpressionUnit>
 										</ExpressionUnarySymbol>
 									</ExpressionExponential>
@@ -115,7 +115,7 @@ the_answer = the_answer - \\z14;
 		</Goal__0__List>
 		<Statement line="3" col="1" source="the_answer = the_answer - &#x5c;z14 ;">
 			<StatementAssignment line="3" col="1" source="the_answer = the_answer - &#x5c;z14 ;">
-				<WORD line="3" col="1" value="0">the_answer</WORD>
+				<WORD line="3" col="1" value="128">the_answer</WORD>
 				<PUNCTUATOR line="3" col="12" value="=">=</PUNCTUATOR>
 				<Expression line="3" col="14" source="the_answer - &#x5c;z14">
 					<ExpressionAdditive line="3" col="14" source="the_answer - &#x5c;z14">
@@ -124,7 +124,7 @@ the_answer = the_answer - \\z14;
 								<ExpressionExponential line="3" col="14" source="the_answer">
 									<ExpressionUnarySymbol line="3" col="14" source="the_answer">
 										<ExpressionUnit line="3" col="14" source="the_answer">
-											<WORD line="3" col="14" value="0">the_answer</WORD>
+											<WORD line="3" col="14" value="128">the_answer</WORD>
 										</ExpressionUnit>
 									</ExpressionUnarySymbol>
 								</ExpressionExponential>
@@ -159,7 +159,7 @@ the_answer = the_answer - \\z14;
 	<StatementList line="1" col="1" source="let unfixed the_answer = 42 ; let \`the £ answer\` = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ;">
 		<Declaration line="1" col="1" source="let unfixed the_answer = 42 ;" type="variable" unfixed="true">
 			<Assignee line="1" col="13" source="the_answer">
-				<Identifier line="1" col="13" source="the_answer" id="0"/>
+				<Identifier line="1" col="13" source="the_answer" id="128"/>
 			</Assignee>
 			<Assigned line="1" col="26" source="42">
 				<Constant line="1" col="26" source="42" value="42"/>
@@ -167,22 +167,22 @@ the_answer = the_answer - \\z14;
 		</Declaration>
 		<Declaration line="2" col="1" source="let \`the £ answer\` = the_answer * 10 ;" type="variable" unfixed="false">
 			<Assignee line="2" col="5" source="\`the £ answer\`">
-				<Identifier line="2" col="5" source="\`the £ answer\`" id="1"/>
+				<Identifier line="2" col="5" source="\`the £ answer\`" id="129"/>
 			</Assignee>
 			<Assigned line="2" col="22" source="the_answer * 10">
 				<Expression line="2" col="22" source="the_answer * 10" operator="*">
-					<Identifier line="2" col="22" source="the_answer" id="0"/>
+					<Identifier line="2" col="22" source="the_answer" id="128"/>
 					<Constant line="2" col="35" source="10" value="10"/>
 				</Expression>
 			</Assigned>
 		</Declaration>
 		<Assignment line="3" col="1" source="the_answer = the_answer - &#x5c;z14 ;">
 			<Assignee line="3" col="1" source="the_answer">
-				<Identifier line="3" col="1" source="the_answer" id="0"/>
+				<Identifier line="3" col="1" source="the_answer" id="128"/>
 			</Assignee>
 			<Assigned line="3" col="14" source="the_answer - &#x5c;z14">
 				<Expression line="3" col="14" source="the_answer - &#x5c;z14" operator="-">
-					<Identifier line="3" col="14" source="the_answer" id="0"/>
+					<Identifier line="3" col="14" source="the_answer" id="128"/>
 					<Constant line="3" col="27" source="&#x5c;z14" value="40"/>
 				</Expression>
 			</Assigned>

--- a/test/statement.test.js
+++ b/test/statement.test.js
@@ -43,16 +43,16 @@ export default __2
 describe('Assignment statements.', () => {
 	const input = `
 let unfixed the_answer = 42;
-let the_high_answer = the_answer * 10;
+let \`the £ answer\` = the_answer * 10;
 the_answer = the_answer - \\z14;
 	`.trim()
 
 	test('Parse assignment statements.', () => {
 		expect(new Parser(input).parse().serialize()).toBe(`
-<Goal source="␂ let unfixed the_answer = 42 ; let the_high_answer = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ; ␃">
+<Goal source="␂ let unfixed the_answer = 42 ; let \`the £ answer\` = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ; ␃">
 	<FILEBOUND value="true">␂</FILEBOUND>
-	<Goal__0__List line="1" col="1" source="let unfixed the_answer = 42 ; let the_high_answer = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ;">
-		<Goal__0__List line="1" col="1" source="let unfixed the_answer = 42 ; let the_high_answer = the_answer * 10 ;">
+	<Goal__0__List line="1" col="1" source="let unfixed the_answer = 42 ; let \`the £ answer\` = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ;">
+		<Goal__0__List line="1" col="1" source="let unfixed the_answer = 42 ; let \`the £ answer\` = the_answer * 10 ;">
 			<Goal__0__List line="1" col="1" source="let unfixed the_answer = 42 ;">
 				<Statement line="1" col="1" source="let unfixed the_answer = 42 ;">
 					<DeclarationVariable line="1" col="1" source="let unfixed the_answer = 42 ;">
@@ -79,29 +79,29 @@ the_answer = the_answer - \\z14;
 					</DeclarationVariable>
 				</Statement>
 			</Goal__0__List>
-			<Statement line="2" col="1" source="let the_high_answer = the_answer * 10 ;">
-				<DeclarationVariable line="2" col="1" source="let the_high_answer = the_answer * 10 ;">
+			<Statement line="2" col="1" source="let \`the £ answer\` = the_answer * 10 ;">
+				<DeclarationVariable line="2" col="1" source="let \`the £ answer\` = the_answer * 10 ;">
 					<WORD line="2" col="1" value="let">let</WORD>
-					<WORD line="2" col="5" value="1">the_high_answer</WORD>
-					<PUNCTUATOR line="2" col="21" value="=">=</PUNCTUATOR>
-					<Expression line="2" col="23" source="the_answer * 10">
-						<ExpressionAdditive line="2" col="23" source="the_answer * 10">
-							<ExpressionMultiplicative line="2" col="23" source="the_answer * 10">
-								<ExpressionMultiplicative line="2" col="23" source="the_answer">
-									<ExpressionExponential line="2" col="23" source="the_answer">
-										<ExpressionUnarySymbol line="2" col="23" source="the_answer">
-											<ExpressionUnit line="2" col="23" source="the_answer">
-												<WORD line="2" col="23" value="0">the_answer</WORD>
+					<WORD line="2" col="5" value="1">\`the £ answer\`</WORD>
+					<PUNCTUATOR line="2" col="20" value="=">=</PUNCTUATOR>
+					<Expression line="2" col="22" source="the_answer * 10">
+						<ExpressionAdditive line="2" col="22" source="the_answer * 10">
+							<ExpressionMultiplicative line="2" col="22" source="the_answer * 10">
+								<ExpressionMultiplicative line="2" col="22" source="the_answer">
+									<ExpressionExponential line="2" col="22" source="the_answer">
+										<ExpressionUnarySymbol line="2" col="22" source="the_answer">
+											<ExpressionUnit line="2" col="22" source="the_answer">
+												<WORD line="2" col="22" value="0">the_answer</WORD>
 											</ExpressionUnit>
 										</ExpressionUnarySymbol>
 									</ExpressionExponential>
 								</ExpressionMultiplicative>
-								<PUNCTUATOR line="2" col="34" value="*">*</PUNCTUATOR>
-								<ExpressionExponential line="2" col="36" source="10">
-									<ExpressionUnarySymbol line="2" col="36" source="10">
-										<ExpressionUnit line="2" col="36" source="10">
-											<PrimitiveLiteral line="2" col="36" source="10">
-												<NUMBER line="2" col="36" value="10">10</NUMBER>
+								<PUNCTUATOR line="2" col="33" value="*">*</PUNCTUATOR>
+								<ExpressionExponential line="2" col="35" source="10">
+									<ExpressionUnarySymbol line="2" col="35" source="10">
+										<ExpressionUnit line="2" col="35" source="10">
+											<PrimitiveLiteral line="2" col="35" source="10">
+												<NUMBER line="2" col="35" value="10">10</NUMBER>
 											</PrimitiveLiteral>
 										</ExpressionUnit>
 									</ExpressionUnarySymbol>
@@ -109,7 +109,7 @@ the_answer = the_answer - \\z14;
 							</ExpressionMultiplicative>
 						</ExpressionAdditive>
 					</Expression>
-					<PUNCTUATOR line="2" col="38" value=";">;</PUNCTUATOR>
+					<PUNCTUATOR line="2" col="37" value=";">;</PUNCTUATOR>
 				</DeclarationVariable>
 			</Statement>
 		</Goal__0__List>
@@ -155,8 +155,8 @@ the_answer = the_answer - \\z14;
 
 	test('Decorate assignment statements.', () => {
 		expect(new Parser(input).parse().decorate().serialize()).toBe(`
-<Goal source="␂ let unfixed the_answer = 42 ; let the_high_answer = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ; ␃">
-	<StatementList line="1" col="1" source="let unfixed the_answer = 42 ; let the_high_answer = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ;">
+<Goal source="␂ let unfixed the_answer = 42 ; let \`the £ answer\` = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ; ␃">
+	<StatementList line="1" col="1" source="let unfixed the_answer = 42 ; let \`the £ answer\` = the_answer * 10 ; the_answer = the_answer - &#x5c;z14 ;">
 		<Declaration line="1" col="1" source="let unfixed the_answer = 42 ;" type="variable" unfixed="true">
 			<Assignee line="1" col="13" source="the_answer">
 				<Identifier line="1" col="13" source="the_answer" id="0"/>
@@ -165,14 +165,14 @@ the_answer = the_answer - \\z14;
 				<Constant line="1" col="26" source="42" value="42"/>
 			</Assigned>
 		</Declaration>
-		<Declaration line="2" col="1" source="let the_high_answer = the_answer * 10 ;" type="variable" unfixed="false">
-			<Assignee line="2" col="5" source="the_high_answer">
-				<Identifier line="2" col="5" source="the_high_answer" id="1"/>
+		<Declaration line="2" col="1" source="let \`the £ answer\` = the_answer * 10 ;" type="variable" unfixed="false">
+			<Assignee line="2" col="5" source="\`the £ answer\`">
+				<Identifier line="2" col="5" source="\`the £ answer\`" id="1"/>
 			</Assignee>
-			<Assigned line="2" col="23" source="the_answer * 10">
-				<Expression line="2" col="23" source="the_answer * 10" operator="*">
-					<Identifier line="2" col="23" source="the_answer" id="0"/>
-					<Constant line="2" col="36" source="10" value="10"/>
+			<Assigned line="2" col="22" source="the_answer * 10">
+				<Expression line="2" col="22" source="the_answer * 10" operator="*">
+					<Identifier line="2" col="22" source="the_answer" id="0"/>
+					<Constant line="2" col="35" source="10" value="10"/>
 				</Expression>
 			</Assigned>
 		</Declaration>

--- a/test/word.test.js
+++ b/test/word.test.js
@@ -3,7 +3,7 @@ const {default: Screener} = require('../build/class/Screener.class.js')
 const {
 	TokenWhitespace,
 	TokenWord,
-	TokenWordStandard,
+	TokenWordBasic,
 	TokenWordUnicode,
 } = require('../build/class/Token.class.js')
 const {
@@ -12,7 +12,7 @@ const {
 
 
 
-describe('Lexer recognizes `TokenWordStandard` conditions.', () => {
+describe('Lexer recognizes `TokenWordBasic` conditions.', () => {
 	const CHAR_START = 'A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z _'.split(' ')
 	const CHAR_REST = CHAR_START.concat('0 1 2 3 4 5 6 7 8 9'.split(' '))
 	test('Word beginners.', () => {
@@ -28,7 +28,7 @@ _words _can _start _with _underscores
 _and0 _can1 contain2 numb3rs
 		`.trim()).generate()].slice(1, -1)
 		tokens.forEach((token) => {
-			expect(token).toBeInstanceOf(TokenWordStandard)
+			expect(token).toBeInstanceOf(TokenWordBasic)
 		})
 		expect(tokens.length).toBe(13)
 	})
@@ -47,8 +47,8 @@ this is a word _words c_an _start w_ith _underscores _and0 c_an1 contain2 numb3r
 
 
 
-describe('Screener assigns word values for standard words.', () => {
-	test('TokenWordStandard#serialize for keywords.', () => {
+describe('Screener assigns word values for basic words.', () => {
+	test('TokenWordBasic#serialize for keywords.', () => {
 		expect([...new Screener(`
 let unfixed
 		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
@@ -57,7 +57,7 @@ let unfixed
 		`.trim())
 	})
 
-	test('TokenWordStandard#serialize for identifiers.', () => {
+	test('TokenWordBasic#serialize for identifiers.', () => {
 		expect([...new Screener(`
 this is a word
 _words _can _start _with _underscores

--- a/test/word.test.js
+++ b/test/word.test.js
@@ -52,8 +52,8 @@ describe('Screener assigns word values for basic words.', () => {
 		expect([...new Screener(`
 let unfixed
 		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
-<WORD line="1" col="1" value="let">let</WORD>
-<WORD line="1" col="5" value="unfixed">unfixed</WORD>
+<WORD line="1" col="1" value="0">let</WORD>
+<WORD line="1" col="5" value="1">unfixed</WORD>
 		`.trim())
 	})
 
@@ -65,27 +65,27 @@ _and0 _can1 contain2 numb3rs
 
 a word _can repeat _with the same id
 		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
-<WORD line="1" col="1" value="0">this</WORD>
-<WORD line="1" col="6" value="1">is</WORD>
-<WORD line="1" col="9" value="2">a</WORD>
-<WORD line="1" col="11" value="3">word</WORD>
-<WORD line="2" col="1" value="4">_words</WORD>
-<WORD line="2" col="8" value="5">_can</WORD>
-<WORD line="2" col="13" value="6">_start</WORD>
-<WORD line="2" col="20" value="7">_with</WORD>
-<WORD line="2" col="26" value="8">_underscores</WORD>
-<WORD line="3" col="1" value="9">_and0</WORD>
-<WORD line="3" col="7" value="10">_can1</WORD>
-<WORD line="3" col="13" value="11">contain2</WORD>
-<WORD line="3" col="22" value="12">numb3rs</WORD>
-<WORD line="5" col="1" value="2">a</WORD>
-<WORD line="5" col="3" value="3">word</WORD>
-<WORD line="5" col="8" value="5">_can</WORD>
-<WORD line="5" col="13" value="13">repeat</WORD>
-<WORD line="5" col="20" value="7">_with</WORD>
-<WORD line="5" col="26" value="14">the</WORD>
-<WORD line="5" col="30" value="15">same</WORD>
-<WORD line="5" col="35" value="16">id</WORD>
+<WORD line="1" col="1" value="128">this</WORD>
+<WORD line="1" col="6" value="129">is</WORD>
+<WORD line="1" col="9" value="130">a</WORD>
+<WORD line="1" col="11" value="131">word</WORD>
+<WORD line="2" col="1" value="132">_words</WORD>
+<WORD line="2" col="8" value="133">_can</WORD>
+<WORD line="2" col="13" value="134">_start</WORD>
+<WORD line="2" col="20" value="135">_with</WORD>
+<WORD line="2" col="26" value="136">_underscores</WORD>
+<WORD line="3" col="1" value="137">_and0</WORD>
+<WORD line="3" col="7" value="138">_can1</WORD>
+<WORD line="3" col="13" value="139">contain2</WORD>
+<WORD line="3" col="22" value="140">numb3rs</WORD>
+<WORD line="5" col="1" value="130">a</WORD>
+<WORD line="5" col="3" value="131">word</WORD>
+<WORD line="5" col="8" value="133">_can</WORD>
+<WORD line="5" col="13" value="141">repeat</WORD>
+<WORD line="5" col="20" value="135">_with</WORD>
+<WORD line="5" col="26" value="142">the</WORD>
+<WORD line="5" col="30" value="143">same</WORD>
+<WORD line="5" col="35" value="144">id</WORD>
 		`.trim())
 	})
 })
@@ -128,19 +128,19 @@ describe('Screener assigns word values for unicode words.', () => {
 \`any\` \`unicode word\` \`can\` \`contain\` \`any\` \`character\`
 \`except\` \`back-ticks\` \`.\`
 		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
-<WORD line="1" col="1" value="0">\`this\`</WORD>
-<WORD line="1" col="8" value="1">\`is\`</WORD>
-<WORD line="1" col="13" value="2">\`a\`</WORD>
-<WORD line="1" col="17" value="3">\`unicode word\`</WORD>
-<WORD line="2" col="1" value="4">\`any\`</WORD>
-<WORD line="2" col="7" value="3">\`unicode word\`</WORD>
-<WORD line="2" col="22" value="5">\`can\`</WORD>
-<WORD line="2" col="28" value="6">\`contain\`</WORD>
-<WORD line="2" col="38" value="4">\`any\`</WORD>
-<WORD line="2" col="44" value="7">\`character\`</WORD>
-<WORD line="3" col="1" value="8">\`except\`</WORD>
-<WORD line="3" col="10" value="9">\`back-ticks\`</WORD>
-<WORD line="3" col="23" value="10">\`.\`</WORD>
+<WORD line="1" col="1" value="128">\`this\`</WORD>
+<WORD line="1" col="8" value="129">\`is\`</WORD>
+<WORD line="1" col="13" value="130">\`a\`</WORD>
+<WORD line="1" col="17" value="131">\`unicode word\`</WORD>
+<WORD line="2" col="1" value="132">\`any\`</WORD>
+<WORD line="2" col="7" value="131">\`unicode word\`</WORD>
+<WORD line="2" col="22" value="133">\`can\`</WORD>
+<WORD line="2" col="28" value="134">\`contain\`</WORD>
+<WORD line="2" col="38" value="132">\`any\`</WORD>
+<WORD line="2" col="44" value="135">\`character\`</WORD>
+<WORD line="3" col="1" value="136">\`except\`</WORD>
+<WORD line="3" col="10" value="137">\`back-ticks\`</WORD>
+<WORD line="3" col="23" value="138">\`.\`</WORD>
 		`.trim())
 	})
 })

--- a/test/word.test.js
+++ b/test/word.test.js
@@ -4,10 +4,13 @@ const {
 	TokenWhitespace,
 	TokenWord,
 } = require('../build/class/Token.class.js')
+const {
+	LexError02,
+} = require('../build/error/LexError.class.js')
 
 
 
-describe('Lexer recognizes `TokenWord` conditions.', () => {
+describe('Lexer recognizes `TokenWord` conditions for non-unicode words.', () => {
 	const CHAR_START = 'A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z _'.split(' ')
 	const CHAR_REST = CHAR_START.concat('0 1 2 3 4 5 6 7 8 9'.split(' '))
 	test('Word beginners.', () => {
@@ -42,16 +45,16 @@ this is a word _words c_an _start w_ith _underscores _and0 c_an1 contain2 numb3r
 
 
 
-describe('Screener assigns word values.', () => {
+describe('Screener assigns word values for non-unicode words.', () => {
 	const printToken = (token) => `${token.cook()}: ${token.source}`
-	test('Identifier word value is itself.', () => {
+	test('Keyword word value is itself.', () => {
 		expect([...new Screener(`let unfixed`).generate()].filter((token) => token instanceof TokenWord).map(printToken).join('\n')).toBe(`
 let: let
 unfixed: unfixed
 		`.trim())
 	})
 
-	test('Non-identifier word values is unique number.', () => {
+	test('Identifier word value is unique number.', () => {
 		expect([...new Screener(`
 this is a word
 _words _can _start _with _underscores
@@ -80,6 +83,62 @@ a word _can repeat _with the same id
 14: the
 15: same
 16: id
+		`.trim())
+	})
+})
+
+
+
+describe('Lexer recognizes `TokenWord` conditions for unicode words.', () => {
+	test('Word boundaries.', () => {
+		const tokens = [...new Screener(`
+\`this\` \`is\` \`a\` \`unicode word\`
+\`any\` \`unicode word\` \`can\` \`contain\` \`any\` \`character\`
+\`except\` \`back-ticks\` \`.\`
+\`<hello world>\` \`Æther\` \`5 × 3\` \`\\u{24}hello\` \`\`
+		`.trim()).generate()].slice(1, -1)
+		expect(tokens.length).toBe(18)
+		tokens.forEach((token) => {
+			expect(token).toBeInstanceOf(TokenWord)
+		})
+	})
+
+	test('Unicode words cannot contain U+0060 GRAVE ACCENT.', () => {
+		expect(() => [...new Screener(`
+\`a \\\` grave accent\`
+		`.trim()).generate()]).toThrow(LexError02)
+	})
+
+	test('Unicode words cannot contain U+0003 END OF TEXT.', () => {
+		expect(() => [...new Screener(`
+\`an \u0003 end of text.\`
+		`.trim()).generate()]).toThrow(LexError02)
+	})
+})
+
+
+
+describe('Screener assigns word values for unicode words.', () => {
+	const printToken = (token) => `${token.cook()}: ${token.source}`
+	test('Identifier word value is unique number.', () => {
+		expect([...new Screener(`
+\`this\` \`is\` \`a\` \`unicode word\`
+\`any\` \`unicode word\` \`can\` \`contain\` \`any\` \`character\`
+\`except\` \`back-ticks\` \`.\`
+		`.trim()).generate()].filter((token) => token instanceof TokenWord).map(printToken).join('\n')).toBe(`
+0: \`this\`
+1: \`is\`
+2: \`a\`
+3: \`unicode word\`
+4: \`any\`
+3: \`unicode word\`
+5: \`can\`
+6: \`contain\`
+4: \`any\`
+7: \`character\`
+8: \`except\`
+9: \`back-ticks\`
+10: \`.\`
 		`.trim())
 	})
 })

--- a/test/word.test.js
+++ b/test/word.test.js
@@ -3,6 +3,8 @@ const {default: Screener} = require('../build/class/Screener.class.js')
 const {
 	TokenWhitespace,
 	TokenWord,
+	TokenWordStandard,
+	TokenWordUnicode,
 } = require('../build/class/Token.class.js')
 const {
 	LexError02,
@@ -10,7 +12,7 @@ const {
 
 
 
-describe('Lexer recognizes `TokenWord` conditions for non-unicode words.', () => {
+describe('Lexer recognizes `TokenWordStandard` conditions.', () => {
 	const CHAR_START = 'A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z _'.split(' ')
 	const CHAR_REST = CHAR_START.concat('0 1 2 3 4 5 6 7 8 9'.split(' '))
 	test('Word beginners.', () => {
@@ -20,23 +22,23 @@ describe('Lexer recognizes `TokenWord` conditions for non-unicode words.', () =>
 	})
 
 	test('Word continuations.', () => {
-		const tokens = [...new Lexer(`
+		const tokens = [...new Screener(`
 this is a word
 _words _can _start _with _underscores
 _and0 _can1 contain2 numb3rs
-		`.trim()).generate()].slice(1, -1).filter((token) => !(token instanceof TokenWhitespace))
+		`.trim()).generate()].slice(1, -1)
 		tokens.forEach((token) => {
-			expect(token).toBeInstanceOf(TokenWord)
+			expect(token).toBeInstanceOf(TokenWordStandard)
 		})
 		expect(tokens.length).toBe(13)
 	})
 
 	test('Words cannot start with a digit.', () => {
-		const tokens = [...new Lexer(`
+		const tokens = [...new Screener(`
 this is 0a word
 _words 1c_an _start 2w_ith _underscores
 _and0 3c_an1 contain2 44numb3rs
-		`.trim()).generate()].slice(1, -1).filter((token) => !(token instanceof TokenWhitespace))
+		`.trim()).generate()].slice(1, -1)
 		expect(tokens.filter((token) => token instanceof TokenWord).map((token) => token.source).join(' ')).toBe(`
 this is a word _words c_an _start w_ith _underscores _and0 c_an1 contain2 numb3rs
 		`.trim())
@@ -45,7 +47,7 @@ this is a word _words c_an _start w_ith _underscores _and0 c_an1 contain2 numb3r
 
 
 
-describe('Screener assigns word values for non-unicode words.', () => {
+describe('Screener assigns word values for standard words.', () => {
 	const printToken = (token) => `${token.cook()}: ${token.source}`
 	test('Keyword word value is itself.', () => {
 		expect([...new Screener(`let unfixed`).generate()].filter((token) => token instanceof TokenWord).map(printToken).join('\n')).toBe(`
@@ -89,7 +91,7 @@ a word _can repeat _with the same id
 
 
 
-describe('Lexer recognizes `TokenWord` conditions for unicode words.', () => {
+describe('Lexer recognizes `TokenWordUnicode` conditions.', () => {
 	test('Word boundaries.', () => {
 		const tokens = [...new Screener(`
 \`this\` \`is\` \`a\` \`unicode word\`
@@ -99,7 +101,7 @@ describe('Lexer recognizes `TokenWord` conditions for unicode words.', () => {
 		`.trim()).generate()].slice(1, -1)
 		expect(tokens.length).toBe(18)
 		tokens.forEach((token) => {
-			expect(token).toBeInstanceOf(TokenWord)
+			expect(token).toBeInstanceOf(TokenWordUnicode)
 		})
 	})
 

--- a/test/word.test.js
+++ b/test/word.test.js
@@ -48,43 +48,44 @@ this is a word _words c_an _start w_ith _underscores _and0 c_an1 contain2 numb3r
 
 
 describe('Screener assigns word values for standard words.', () => {
-	const printToken = (token) => `${token.cook()}: ${token.source}`
-	test('Keyword word value is itself.', () => {
-		expect([...new Screener(`let unfixed`).generate()].filter((token) => token instanceof TokenWord).map(printToken).join('\n')).toBe(`
-let: let
-unfixed: unfixed
+	test('TokenWordStandard#serialize for keywords.', () => {
+		expect([...new Screener(`
+let unfixed
+		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
+<WORD line="1" col="1" value="let">let</WORD>
+<WORD line="1" col="5" value="unfixed">unfixed</WORD>
 		`.trim())
 	})
 
-	test('Identifier word value is unique number.', () => {
+	test('TokenWordStandard#serialize for identifiers.', () => {
 		expect([...new Screener(`
 this is a word
 _words _can _start _with _underscores
 _and0 _can1 contain2 numb3rs
 
 a word _can repeat _with the same id
-		`.trim()).generate()].filter((token) => token instanceof TokenWord).map(printToken).join('\n')).toBe(`
-0: this
-1: is
-2: a
-3: word
-4: _words
-5: _can
-6: _start
-7: _with
-8: _underscores
-9: _and0
-10: _can1
-11: contain2
-12: numb3rs
-2: a
-3: word
-5: _can
-13: repeat
-7: _with
-14: the
-15: same
-16: id
+		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
+<WORD line="1" col="1" value="0">this</WORD>
+<WORD line="1" col="6" value="1">is</WORD>
+<WORD line="1" col="9" value="2">a</WORD>
+<WORD line="1" col="11" value="3">word</WORD>
+<WORD line="2" col="1" value="4">_words</WORD>
+<WORD line="2" col="8" value="5">_can</WORD>
+<WORD line="2" col="13" value="6">_start</WORD>
+<WORD line="2" col="20" value="7">_with</WORD>
+<WORD line="2" col="26" value="8">_underscores</WORD>
+<WORD line="3" col="1" value="9">_and0</WORD>
+<WORD line="3" col="7" value="10">_can1</WORD>
+<WORD line="3" col="13" value="11">contain2</WORD>
+<WORD line="3" col="22" value="12">numb3rs</WORD>
+<WORD line="5" col="1" value="2">a</WORD>
+<WORD line="5" col="3" value="3">word</WORD>
+<WORD line="5" col="8" value="5">_can</WORD>
+<WORD line="5" col="13" value="13">repeat</WORD>
+<WORD line="5" col="20" value="7">_with</WORD>
+<WORD line="5" col="26" value="14">the</WORD>
+<WORD line="5" col="30" value="15">same</WORD>
+<WORD line="5" col="35" value="16">id</WORD>
 		`.trim())
 	})
 })
@@ -121,26 +122,25 @@ describe('Lexer recognizes `TokenWordUnicode` conditions.', () => {
 
 
 describe('Screener assigns word values for unicode words.', () => {
-	const printToken = (token) => `${token.cook()}: ${token.source}`
-	test('Identifier word value is unique number.', () => {
+	test('TokenWordUnicode#serialize', () => {
 		expect([...new Screener(`
 \`this\` \`is\` \`a\` \`unicode word\`
 \`any\` \`unicode word\` \`can\` \`contain\` \`any\` \`character\`
 \`except\` \`back-ticks\` \`.\`
-		`.trim()).generate()].filter((token) => token instanceof TokenWord).map(printToken).join('\n')).toBe(`
-0: \`this\`
-1: \`is\`
-2: \`a\`
-3: \`unicode word\`
-4: \`any\`
-3: \`unicode word\`
-5: \`can\`
-6: \`contain\`
-4: \`any\`
-7: \`character\`
-8: \`except\`
-9: \`back-ticks\`
-10: \`.\`
+		`.trim()).generate()].filter((token) => token instanceof TokenWord).map((token) => token.serialize()).join('\n')).toBe(`
+<WORD line="1" col="1" value="0">\`this\`</WORD>
+<WORD line="1" col="8" value="1">\`is\`</WORD>
+<WORD line="1" col="13" value="2">\`a\`</WORD>
+<WORD line="1" col="17" value="3">\`unicode word\`</WORD>
+<WORD line="2" col="1" value="4">\`any\`</WORD>
+<WORD line="2" col="7" value="3">\`unicode word\`</WORD>
+<WORD line="2" col="22" value="5">\`can\`</WORD>
+<WORD line="2" col="28" value="6">\`contain\`</WORD>
+<WORD line="2" col="38" value="4">\`any\`</WORD>
+<WORD line="2" col="44" value="7">\`character\`</WORD>
+<WORD line="3" col="1" value="8">\`except\`</WORD>
+<WORD line="3" col="10" value="9">\`back-ticks\`</WORD>
+<WORD line="3" col="23" value="10">\`.\`</WORD>
 		`.trim())
 	})
 })


### PR DESCRIPTION
Lexical grammar:
```
Word ::= [A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`"
```
Word Value:
```
WV(Word ::= ([A-Za-z_] [A-Za-z0-9_]* | "`" [^`#x03]* "`") - Keyword)
	:= /* TO BE DETERMINED */
```

Identifiers may be enclosed in back-ticks (`` ` ` `` **U+0060 GRAVE ACCENT**) to allow non-alphanumeric Unicode characters.
```
let `españa` = 'Spanish for “Spain”';
let `svaret_på_den_ultimata_frågan` = 42; % Sweedish for “the answer to the ultimate question”
```

Any character except **U+0060 GRAVE ACCENT** and **U+0003 END OF TEXT** is allowed inside the delimiters of a Unicode identifier name. These forbidden characters cannot be escaped. In fact, escape sequences of any kind are not possible: `` `\u{24}αβγ` `` and `` `$αβγ` `` are two *different* identifier names, and `` `\t` `` and `` `	` `` are also different (the latter of these contains a literal tab character **U+0009**). Unicode identifier names *should not* contain whitespace.

Unicode identifiers may also contain no characters: the token `` `​` `` is a valid identifier.

Identifiers that are declared as Unicode identifiers must always be referenced as such. A ReferenceError should be thrown when attempting to reference an identifier that has not been declared (see #14), even if the identifier differs only in back-tick delimiters.
```
let `foo` = 16;
foo;            % ReferenceError (foo is not declared)
let bar = 24;
`bar`;          % ReferenceError (`bar` is not declared)
```
This means that the identifiers `foo` and `` `foo` `` can refer to different values.
```
let foo = 8;
let `foo` = 16; % allowed
```
